### PR TITLE
added require relative to make connectionadapter class accessible

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,10 +22,15 @@ GEM
     json (1.8.3)
     method_source (0.8.2)
     minitest (5.7.0)
+    mustermann (1.0.2)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    rack (2.0.5)
+    rack-protection (2.0.1)
+      rack
+    rake (12.3.1)
     rspec (3.3.0)
       rspec-core (~> 3.3.0)
       rspec-expectations (~> 3.3.0)
@@ -39,9 +44,18 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.3.0)
     rspec-support (3.3.0)
+    sinatra (2.0.1)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.1)
+      tilt (~> 2.0)
+    sinatra-activerecord (2.0.13)
+      activerecord (>= 3.2)
+      sinatra (>= 1.0)
     slop (3.6.0)
     sqlite3 (1.3.10)
     thread_safe (0.3.5)
+    tilt (2.0.8)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
 
@@ -51,5 +65,10 @@ PLATFORMS
 DEPENDENCIES
   activerecord
   pry
+  rake
   rspec
+  sinatra-activerecord
   sqlite3
+
+BUNDLED WITH
+   1.16.1

--- a/lib/support/db_registry.rb
+++ b/lib/support/db_registry.rb
@@ -1,4 +1,6 @@
 require 'ostruct'
+require_relative './connection_adapter.rb'
+
 DBRegistry ||= OpenStruct.new(test: ConnectionAdapter.new("db/playlister-test.db"), 
   development: ConnectionAdapter.new("db/playlister-development.db"), 
   production: ConnectionAdapter.new("db/playlister-production.db")


### PR DESCRIPTION
rspec was failing until I added the require_relative line.  I've been having a lot of environment difficulties aside from this so someone should double-check